### PR TITLE
Fixed compile error

### DIFF
--- a/JdSoft.Apple.Apns.Notifications/NotificationChannel.cs
+++ b/JdSoft.Apple.Apns.Notifications/NotificationChannel.cs
@@ -285,7 +285,7 @@ namespace JdSoft.Apple.Apns.Notifications
 
 					try
 					{
-						notificationBytes = notification.ToBytes(current);
+						notificationBytes = notification.ToBytes();
 					}
 					catch (Exception x)
 					{


### PR DESCRIPTION
Notification.ToBytes no longer takes an argument. NotificationChannel.SendMessages was still trying to pass an argument to Notification.ToBytes
