### PR TITLE
Certificates with no password

### DIFF
--- a/JdSoft.Apple.Apns.Feedback/FeedbackService.cs
+++ b/JdSoft.Apple.Apns.Feedback/FeedbackService.cs
@@ -87,7 +87,7 @@ namespace JdSoft.Apple.Apns.Feedback
  	    //      The default is UserKeySet, which has caused internal encryption errors,
  	    //      Because of lack of permissions on most hosting services.
  	    //      So MachineKeySet should be used instead.
-            certificate = new X509Certificate2(p12FileBytes, "", X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
+            certificate = new X509Certificate2(p12FileBytes, null, X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
             ConnectAttempts = 3;
             ReconnectDelay = 10000;
         }
@@ -126,7 +126,7 @@ namespace JdSoft.Apple.Apns.Feedback
  	    //      The default is UserKeySet, which has caused internal encryption errors,
  	    //      Because of lack of permissions on most hosting services.
  	    //      So MachineKeySet should be used instead.
-            certificate = new X509Certificate2(p12FileBytes, p12FilePassword ?? "", X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
+            certificate = new X509Certificate2(p12FileBytes, p12FilePassword, X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
             P12FilePassword = p12FilePassword;
             ConnectAttempts = 3;
             ReconnectDelay = 10000;
@@ -160,7 +160,7 @@ namespace JdSoft.Apple.Apns.Feedback
  	    //      The default is UserKeySet, which has caused internal encryption errors,
  	    //      Because of lack of permissions on most hosting services.
  	    //      So MachineKeySet should be used instead.
-            certificate = new X509Certificate2(p12FileBytes, "", X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
+            certificate = new X509Certificate2(p12FileBytes, null, X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
             ConnectAttempts = 3;
         }
 
@@ -196,7 +196,7 @@ namespace JdSoft.Apple.Apns.Feedback
  	    //      The default is UserKeySet, which has caused internal encryption errors,
  	    //      Because of lack of permissions on most hosting services.
  	    //      So MachineKeySet should be used instead.
-            certificate = new X509Certificate2(p12FileBytes, p12FilePassword ?? "", X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
+            certificate = new X509Certificate2(p12FileBytes, p12FilePassword, X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
             P12FilePassword = p12FilePassword;
             ConnectAttempts = 3;
             ReconnectDelay = 10000;
@@ -231,7 +231,7 @@ namespace JdSoft.Apple.Apns.Feedback
  	        //      The default is UserKeySet, which has caused internal encryption errors,
  	        //      Because of lack of permissions on most hosting services.
  	        //      So MachineKeySet should be used instead.
-                certificate = new X509Certificate2(System.IO.File.ReadAllBytes(P12File), P12FilePassword ?? "", X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
+                certificate = new X509Certificate2(System.IO.File.ReadAllBytes(P12File), P12FilePassword, X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
  	    }
 
 			certificates = new X509CertificateCollection();

--- a/JdSoft.Apple.Apns.Notifications/NotificationChannel.cs
+++ b/JdSoft.Apple.Apns.Notifications/NotificationChannel.cs
@@ -195,7 +195,7 @@ namespace JdSoft.Apple.Apns.Notifications
             //      The default is UserKeySet, which has caused internal encryption errors,
             //      Because of lack of permissions on most hosting services.
             //      So MachineKeySet should be used instead.
-            certificate = new X509Certificate2(p12FileBytes, p12FilePassword ?? "", X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
+            certificate = new X509Certificate2(p12FileBytes, p12FilePassword, X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
 
             certificates = new X509CertificateCollection();
             certificates.Add(certificate);


### PR DESCRIPTION
As discussed.

When initializing an instance of X509Certificate2 supply null as the password if one hasn't been set instead of an empty string.
