### PR TITLE
Threading, Azure changes

### DIFF
--- a/JdSoft.Apple.Apns.Notifications/NotificationChannel.cs
+++ b/JdSoft.Apple.Apns.Notifications/NotificationChannel.cs
@@ -154,6 +154,16 @@ namespace JdSoft.Apple.Apns.Notifications
         /// Constructor
         /// </summary>
         /// <param name="sandbox">Boolean flag indicating whether the default Sandbox or Production Host and Port should be used</param>
+        /// <param name="cert">X509 Certificate containing Public and Private Keys</param>
+        public NotificationChannel(bool sandbox, X509Certificate2 cert)
+            : this(sandbox ? hostSandbox : hostProduction, 2195, cert)
+        {
+        }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="sandbox">Boolean flag indicating whether the default Sandbox or Production Host and Port should be used</param>
         /// <param name="p12FileBytes">Byte array representation of PKCS12 .p12 or .pfx File containing Public and Private Keys</param>
         /// <param name="p12FilePassword">Password protecting the p12File</param>
         public NotificationChannel(bool sandbox, byte[] p12FileBytes, string p12FilePassword)
@@ -176,11 +186,29 @@ namespace JdSoft.Apple.Apns.Notifications
         /// <summary>
         /// Constructor
         /// </summary>
+        /// <remarks>
+        /// Need to load the private key seperately from apple
+        /// Fixed by danielgindi@gmail.com :
+        ///      The default is UserKeySet, which has caused internal encryption errors,
+        ///      Because of lack of permissions on most hosting services.
+        ///      So MachineKeySet should be used instead.
+        /// </remarks>
         /// <param name="host">Push Notification Gateway Host</param>
         /// <param name="port">Push Notification Gateway Port</param>
         /// <param name="p12FileBytes">Byte array representation of PKCS12 .p12 or .pfx File containing Public and Private Keys</param>
         /// <param name="p12FilePassword">Password protecting the p12File</param>
         public NotificationChannel(string host, int port, byte[] p12FileBytes, string p12FilePassword)
+            : this(host, port, new X509Certificate2(p12FileBytes, p12FilePassword, X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable))
+        {
+        }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="host">Push Notification Gateway Host</param>
+        /// <param name="port">Push Notification Gateway Port</param>
+        /// <param name="cert">X509 Certificate containing Public and Private Keys</param>
+        public NotificationChannel(string host, int port, X509Certificate2 cert)
         {
             Host = host;
             Port = port;
@@ -190,12 +218,7 @@ namespace JdSoft.Apple.Apns.Notifications
             ReconnectDelay = 3000;
             ConnectRetries = 6;
 
-            //Need to load the private key seperately from apple
-            // Fixed by danielgindi@gmail.com :
-            //      The default is UserKeySet, which has caused internal encryption errors,
-            //      Because of lack of permissions on most hosting services.
-            //      So MachineKeySet should be used instead.
-            certificate = new X509Certificate2(p12FileBytes, p12FilePassword, X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
+            certificate = cert;
 
             certificates = new X509CertificateCollection();
             certificates.Add(certificate);

--- a/JdSoft.Apple.Apns.Notifications/NotificationConnection.cs
+++ b/JdSoft.Apple.Apns.Notifications/NotificationConnection.cs
@@ -328,6 +328,7 @@ namespace JdSoft.Apple.Apns.Notifications
 			apnsChannel.Disconnected += new NotificationChannel.OnDisconnected(OnChannelDisconnected);
 
 			workerThread = new Thread(new ThreadStart(workerMethod));
+			workerThread.IsBackground = true;
 			workerThread.Start();
 		}
 

--- a/JdSoft.Apple.Apns.Notifications/NotificationConnection.cs
+++ b/JdSoft.Apple.Apns.Notifications/NotificationConnection.cs
@@ -126,6 +126,18 @@ namespace JdSoft.Apple.Apns.Notifications
 			start();
 		}
 
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		/// <param name="host">Push Notification Gateway Host</param>
+		/// <param name="port">Push Notification Gateway Port</param>
+		/// <param name="cert">X509 Certificate containing Public and Private Keys</param>
+		public NotificationConnection(string host, int port, X509Certificate2 cert)
+		{
+			apnsChannel = new NotificationChannel(host, port, cert);
+			start();
+		}
+
         /// <summary>
         /// Constructor
         /// </summary>
@@ -160,6 +172,17 @@ namespace JdSoft.Apple.Apns.Notifications
 		public NotificationConnection(bool sandbox, string p12File)
 		{
 			apnsChannel = new NotificationChannel(sandbox, p12File);
+			start();
+		}
+
+		/// <summary>
+		/// Constructor
+		/// </summary>
+		/// <param name="sandbox">Boolean flag indicating whether the default Sandbox or Production Host and Port should be used</param>
+		/// <param name="cert">X509 Certificate containing Public and Private Keys</param>
+		public NotificationConnection(bool sandbox, X509Certificate2 cert)
+		{
+			apnsChannel = new NotificationChannel(sandbox, cert);
 			start();
 		}
 

--- a/JdSoft.Apple.Apns.Notifications/NotificationService.cs
+++ b/JdSoft.Apple.Apns.Notifications/NotificationService.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 
 namespace JdSoft.Apple.Apns.Notifications
@@ -149,14 +150,25 @@ namespace JdSoft.Apple.Apns.Notifications
         /// <param name="p12FilePassword">Password protecting the p12File</param>
         /// <param name="connections">Number of Apns Connections to start with</param>
         public NotificationService( string host, int port, byte[] p12FileBytes, string p12FilePassword, int connections )
+            : this( host, port, new X509Certificate2(p12FileBytes, p12FilePassword, X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable), connections )
+        {
+        }
+
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="host">Push Notification Gateway Host</param>
+        /// <param name="port">Push Notification Gateway Port</param>
+        /// <param name="certificate">X509 Certificate containing Public and Private Keys</param>
+        /// <param name="connections">Number of Apns Connections to start with</param>
+        public NotificationService( string host, int port, X509Certificate2 certificate, int connections )
         {
             this.SendRetries = 1;
             closing = false;
             disposing = false;
             Host = host;
             Port = port;
-            P12FileBytes = p12FileBytes;
-            P12FilePassword = p12FilePassword;
+            Certificate = certificate;
             DistributionType = NotificationServiceDistributionType.Sequential;
             Connections = connections;
         }
@@ -262,17 +274,6 @@ namespace JdSoft.Apple.Apns.Notifications
 		}
 
 		/// <summary>
-		/// Gets the PKCS12 .p12 or .pfx File being used
-		/// </summary>
-		public byte[] P12FileBytes
-		{
-			get;
-			private set;
-		}
-
-		private string P12FilePassword;
-
-		/// <summary>
 		/// Gets the Push Notification Gateway Host
 		/// </summary>
 		public string Host
@@ -285,6 +286,15 @@ namespace JdSoft.Apple.Apns.Notifications
 		/// Gets the Push Notification Gateway Port
 		/// </summary>
 		public int Port
+		{
+			get;
+			private set;
+		}
+
+		/// <summary>
+		/// Gets the Push Notification Certificate
+		/// </summary>
+		public X509Certificate2 Certificate
 		{
 			get;
 			private set;
@@ -322,7 +332,7 @@ namespace JdSoft.Apple.Apns.Notifications
 					//Need to add connections
 					for (int i = 0; i < difference; i++)
 					{
-						NotificationConnection newCon = new NotificationConnection(Host, Port, P12FileBytes, P12FilePassword);
+						NotificationConnection newCon = new NotificationConnection(Host, Port, Certificate);
 						newCon.SendRetries = SendRetries;
 						newCon.ReconnectDelay = ReconnectDelay;
 

--- a/JdSoft.Apple.Apns.Notifications/NotificationService.cs
+++ b/JdSoft.Apple.Apns.Notifications/NotificationService.cs
@@ -173,6 +173,17 @@ namespace JdSoft.Apple.Apns.Notifications
             Connections = connections;
         }
 
+	/// <summary>
+	/// Constructor
+	/// </summary>
+	/// <param name="sandbox">Boolean flag indicating whether the default Sandbox or Production Host and Port should be used</param>
+        /// <param name="certificate">X509 Certificate containing Public and Private Keys</param>
+	/// <param name="connections">Number of Apns Connections to start with</param>
+	public NotificationService(bool sandbox, X509Certificate2 certificate, int connections)
+            : this(sandbox ? hostSandbox : hostProduction, apnsPort, certificate, connections)
+	{
+	}
+
 		/// <summary>
 		/// Constructor
 		/// </summary>


### PR DESCRIPTION
- Marked worker thread as background to ensure proper shutdown in test harness apps.
- Added support for instantiating the NotificationService with an X509 certificate. In the Windows Azure environment, this enables usage of the Azure certificate management facilities rather than including the p12 file and password in the file system / config.
