### PR TITLE
TLS instead of SSL3 and compilation fixes

### DIFF
--- a/JdSoft.Apple.Apns.Feedback.Test/JdSoft.Apple.Apns.Feedback.Test.csproj
+++ b/JdSoft.Apple.Apns.Feedback.Test/JdSoft.Apple.Apns.Feedback.Test.csproj
@@ -37,15 +37,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Xml.Linq">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data.DataSetExtensions">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/JdSoft.Apple.Apns.Feedback.Test/Program.cs
+++ b/JdSoft.Apple.Apns.Feedback.Test/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using JdSoft.Apple.Apns.Feedback;
 

--- a/JdSoft.Apple.Apns.Feedback/Feedback.cs
+++ b/JdSoft.Apple.Apns.Feedback/Feedback.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 namespace JdSoft.Apple.Apns.Feedback

--- a/JdSoft.Apple.Apns.Feedback/FeedbackService.cs
+++ b/JdSoft.Apple.Apns.Feedback/FeedbackService.cs
@@ -87,7 +87,7 @@ namespace JdSoft.Apple.Apns.Feedback
  	    //      The default is UserKeySet, which has caused internal encryption errors,
  	    //      Because of lack of permissions on most hosting services.
  	    //      So MachineKeySet should be used instead.
-            certificate = new X509Certificate2(p12FileBytes, null, X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
+            certificate = new X509Certificate2(p12FileBytes, (string)null, X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
             ConnectAttempts = 3;
             ReconnectDelay = 10000;
         }
@@ -160,7 +160,7 @@ namespace JdSoft.Apple.Apns.Feedback
  	    //      The default is UserKeySet, which has caused internal encryption errors,
  	    //      Because of lack of permissions on most hosting services.
  	    //      So MachineKeySet should be used instead.
-            certificate = new X509Certificate2(p12FileBytes, null, X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
+            certificate = new X509Certificate2(p12FileBytes, (string)null, X509KeyStorageFlags.MachineKeySet | X509KeyStorageFlags.PersistKeySet | X509KeyStorageFlags.Exportable);
             ConnectAttempts = 3;
         }
 

--- a/JdSoft.Apple.Apns.Feedback/FeedbackService.cs
+++ b/JdSoft.Apple.Apns.Feedback/FeedbackService.cs
@@ -395,7 +395,7 @@ namespace JdSoft.Apple.Apns.Feedback
 
 					apnsStream.AuthenticateAsClient(Host,
 						certificates,
-						System.Security.Authentication.SslProtocols.Ssl3,
+						System.Security.Authentication.SslProtocols.Tls,
 						false);
 
 					connected = apnsStream.CanWrite;

--- a/JdSoft.Apple.Apns.Feedback/FeedbackService.cs
+++ b/JdSoft.Apple.Apns.Feedback/FeedbackService.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Net;

--- a/JdSoft.Apple.Apns.Feedback/JdSoft.Apple.Apns.Feedback.csproj
+++ b/JdSoft.Apple.Apns.Feedback/JdSoft.Apple.Apns.Feedback.csproj
@@ -37,9 +37,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/JdSoft.Apple.Apns.Notifications.JsonTest/JdSoft.Apple.Apns.Notifications.JsonTest.csproj
+++ b/JdSoft.Apple.Apns.Notifications.JsonTest/JdSoft.Apple.Apns.Notifications.JsonTest.csproj
@@ -33,9 +33,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>

--- a/JdSoft.Apple.Apns.Notifications.Test/JdSoft.Apple.Apns.Notifications.Test.csproj
+++ b/JdSoft.Apple.Apns.Notifications.Test/JdSoft.Apple.Apns.Notifications.Test.csproj
@@ -37,16 +37,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
     <Reference Include="System.Windows.Forms" />
-    <Reference Include="System.Xml.Linq">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data.DataSetExtensions">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/JdSoft.Apple.Apns.Notifications.Test/Program.cs
+++ b/JdSoft.Apple.Apns.Notifications.Test/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using JdSoft.Apple.Apns.Notifications;
 

--- a/JdSoft.Apple.Apns.Notifications/BadDeviceTokenException.cs
+++ b/JdSoft.Apple.Apns.Notifications/BadDeviceTokenException.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 namespace JdSoft.Apple.Apns.Notifications

--- a/JdSoft.Apple.Apns.Notifications/JdSoft.Apple.Apns.Notifications.csproj
+++ b/JdSoft.Apple.Apns.Notifications/JdSoft.Apple.Apns.Notifications.csproj
@@ -40,21 +40,6 @@
       <HintPath>..\packages\Newtonsoft.Json.4.0.8\lib\net35\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Runtime.Serialization">
-      <RequiredTargetFramework>3.0</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.ServiceModel.Web">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Xml.Linq">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data.DataSetExtensions">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/JdSoft.Apple.Apns.Notifications/Notification.cs
+++ b/JdSoft.Apple.Apns.Notifications/Notification.cs
@@ -2,10 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
-using System.Runtime.Serialization;
-using System.Runtime.Serialization.Json;
 using System.Text;
-using System.ServiceModel.Web;
 
 namespace JdSoft.Apple.Apns.Notifications
 {

--- a/JdSoft.Apple.Apns.Notifications/NotificationAlert.cs
+++ b/JdSoft.Apple.Apns.Notifications/NotificationAlert.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using Newtonsoft.Json.Linq;
 

--- a/JdSoft.Apple.Apns.Notifications/NotificationBatchException.cs
+++ b/JdSoft.Apple.Apns.Notifications/NotificationBatchException.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 namespace JdSoft.Apple.Apns.Notifications

--- a/JdSoft.Apple.Apns.Notifications/NotificationChannel.cs
+++ b/JdSoft.Apple.Apns.Notifications/NotificationChannel.cs
@@ -495,7 +495,7 @@ namespace JdSoft.Apple.Apns.Notifications
 
 			try
 			{
-				apnsStream.AuthenticateAsClient(this.Host, this.certificates, System.Security.Authentication.SslProtocols.Ssl3, false);
+				apnsStream.AuthenticateAsClient(this.Host, this.certificates, System.Security.Authentication.SslProtocols.Tls, false);
 			}
 			catch (System.Security.Authentication.AuthenticationException ex)
 			{

--- a/JdSoft.Apple.Apns.Notifications/NotificationChannel.cs
+++ b/JdSoft.Apple.Apns.Notifications/NotificationChannel.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Security.Cryptography.X509Certificates;
 using System.Net.Sockets;

--- a/JdSoft.Apple.Apns.Notifications/NotificationConnection.cs
+++ b/JdSoft.Apple.Apns.Notifications/NotificationConnection.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Net;

--- a/JdSoft.Apple.Apns.Notifications/NotificationDeliveryError.cs
+++ b/JdSoft.Apple.Apns.Notifications/NotificationDeliveryError.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 namespace JdSoft.Apple.Apns.Notifications

--- a/JdSoft.Apple.Apns.Notifications/NotificationException.cs
+++ b/JdSoft.Apple.Apns.Notifications/NotificationException.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 namespace JdSoft.Apple.Apns.Notifications

--- a/JdSoft.Apple.Apns.Notifications/NotificationLengthException.cs
+++ b/JdSoft.Apple.Apns.Notifications/NotificationLengthException.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 namespace JdSoft.Apple.Apns.Notifications

--- a/JdSoft.Apple.Apns.Notifications/NotificationPayload.cs
+++ b/JdSoft.Apple.Apns.Notifications/NotificationPayload.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Net;
-using System.Runtime.Serialization;
-using System.Runtime.Serialization.Json;
 using System.Text;
 using Newtonsoft.Json.Linq;
 

--- a/JdSoft.Apple.Apns.Notifications/NotificationService.cs
+++ b/JdSoft.Apple.Apns.Notifications/NotificationService.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 namespace JdSoft.Apple.Apns.Notifications

--- a/JdSoft.Apple.Apns.Notifications/NotificationServiceDistributionType.cs
+++ b/JdSoft.Apple.Apns.Notifications/NotificationServiceDistributionType.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 namespace JdSoft.Apple.Apns.Notifications

--- a/JdSoft.Apple.Apns.Notifications/ThreadSafeQueue.cs
+++ b/JdSoft.Apple.Apns.Notifications/ThreadSafeQueue.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 
 namespace JdSoft.Apple.Apns.Notifications

--- a/JdSoft.Apple.AppStore.Test/JdSoft.Apple.AppStore.Test.csproj
+++ b/JdSoft.Apple.AppStore.Test/JdSoft.Apple.AppStore.Test.csproj
@@ -37,15 +37,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Xml.Linq">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data.DataSetExtensions">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Deployment" />
     <Reference Include="System.Drawing" />

--- a/JdSoft.Apple.AppStore.Test/Program.cs
+++ b/JdSoft.Apple.AppStore.Test/Program.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Windows.Forms;
 using JdSoft.Apple.AppStore;
 

--- a/JdSoft.Apple.AppStore.Test/frmReceiptData.cs
+++ b/JdSoft.Apple.AppStore.Test/frmReceiptData.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Data;
 using System.Drawing;
-using System.Linq;
 using System.Text;
 using System.Windows.Forms;
 

--- a/JdSoft.Apple.AppStore/JdSoft.Apple.AppStore.csproj
+++ b/JdSoft.Apple.AppStore/JdSoft.Apple.AppStore.csproj
@@ -40,15 +40,6 @@
       <HintPath>..\packages\Newtonsoft.Json.4.0.8\lib\net35\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Xml.Linq">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
-    <Reference Include="System.Data.DataSetExtensions">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
   </ItemGroup>

--- a/JdSoft.Apple.AppStore/Receipt.cs
+++ b/JdSoft.Apple.AppStore/Receipt.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using Newtonsoft.Json.Linq;
 

--- a/JdSoft.Apple.AppStore/ReceiptVerification.cs
+++ b/JdSoft.Apple.AppStore/ReceiptVerification.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Net;

--- a/Tests.Notifications/UnitTest1.cs
+++ b/Tests.Notifications/UnitTest1.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Text;
 using System.Collections.Generic;
-using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using JdSoft.Apple.Apns.Notifications;
 


### PR DESCRIPTION
TLS instead of SSL3, Resolved ambiguous call to X509Certificate2 constructor, and removed a bunch of unnecessary using statements and references assemblies.
